### PR TITLE
Fix retry targeting for message resends

### DIFF
--- a/src/__tests__/Socket/messages-recv.retry.test.ts
+++ b/src/__tests__/Socket/messages-recv.retry.test.ts
@@ -1,0 +1,50 @@
+import { __testing } from '../../Socket/messages-recv'
+import type { BinaryNode } from '../../WABinary'
+
+describe('resolveRetryParticipant', () => {
+        const resolve = __testing.resolveRetryParticipant
+
+        it('returns existing participant when it already includes a device id', () => {
+                const retryNode: BinaryNode = {
+                        tag: 'retry',
+                        attrs: {
+                                count: '1',
+                                participant: 'user:2@s.whatsapp.net'
+                        },
+                        content: undefined
+                }
+
+                const result = resolve('user:1@s.whatsapp.net', 'group@g.us', retryNode)
+                expect(result.jid).toBe('user:1@s.whatsapp.net')
+                expect(result.hasDevice).toBe(true)
+        })
+
+        it('falls back to retry sender when participant lacks device id', () => {
+                const retryNode: BinaryNode = {
+                        tag: 'retry',
+                        attrs: {
+                                count: '1',
+                                from: 'user:4@s.whatsapp.net'
+                        },
+                        content: undefined
+                }
+
+                const result = resolve('user@s.whatsapp.net', 'group@g.us', retryNode)
+                expect(result.jid).toBe('user:4@s.whatsapp.net')
+                expect(result.hasDevice).toBe(true)
+        })
+
+        it('returns fallback without device id when none is available', () => {
+                const retryNode: BinaryNode = {
+                        tag: 'retry',
+                        attrs: {
+                                count: '1'
+                        },
+                        content: undefined
+                }
+
+                const result = resolve('user@s.whatsapp.net', 'group@g.us', retryNode)
+                expect(result.jid).toBe('user@s.whatsapp.net')
+                expect(result.hasDevice).toBe(false)
+        })
+})


### PR DESCRIPTION
## Summary
- resolve retry resend participant JIDs from retry metadata so relays target the requesting device and add defensive logging when falling back to broadcast
- expose the participant resolution helper for testing and cover its fallback cases with a dedicated unit test

## Testing
- yarn test --runTestsByPath src/__tests__/Socket/messages-recv.retry.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68de0adefe04832d89b2c63a61145891