### PR TITLE
Fix registration handshake when pairing credentials already exist

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -380,7 +380,7 @@ export const makeSocket = (config: SocketConfig) => {
 		const keyEnc = await noise.processHandshake(handshake, creds.noiseKey)
 
 		let node: proto.IClientPayload
-		if (!creds.me) {
+                if (!creds.me || !creds.registered) {
 			node = generateRegistrationNode(creds, config)
 			logger.info({ node }, 'not logged in, attempting registration...')
 		} else {


### PR DESCRIPTION
## Summary
- ensure a new socket registration is attempted when credentials are not yet registered
- prevent premature login attempts that caused pairing sessions to fail before showing a QR code

## Testing
- yarn test --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68edb8355860832d94f451578776ae61