### PR TITLE
Clean up caches and timers to avoid resource leaks

### DIFF
--- a/src/Socket/messages-send.ts
+++ b/src/Socket/messages-send.ts
@@ -78,12 +78,16 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 		groupToggleEphemeral
 	} = sock
 
+	const shouldCloseUserDevicesCache = !config.userDevicesCache
 	const userDevicesCache =
 		config.userDevicesCache ||
 		new NodeCache<JidWithDevice[]>({
 			stdTTL: DEFAULT_CACHE_TTLS.USER_DEVICES, // 5 minutes
 			useClones: false
 		})
+	const localUserDevicesCache = shouldCloseUserDevicesCache
+		? (userDevicesCache as NodeCache<JidWithDevice[]>)
+		: undefined
 
 	const peerSessionsCache = new NodeCache<boolean>({
 		stdTTL: DEFAULT_CACHE_TTLS.USER_DEVICES,
@@ -92,6 +96,19 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 
 	// Initialize message retry manager if enabled
 	const messageRetryManager = enableRecentMessageCache ? new MessageRetryManager(logger, maxMsgRetryCount) : null
+
+	const baseEnd = sock.end
+	let resourcesClosed = false
+	const cleanupResources = () => {
+		if (resourcesClosed) {
+			return
+		}
+
+		resourcesClosed = true
+		peerSessionsCache.close()
+		localUserDevicesCache?.close()
+		messageRetryManager?.shutdown()
+	}
 
 	// Prevent race conditions in Signal session encryption by user
 	const encryptionMutex = makeKeyedMutex()
@@ -1003,8 +1020,14 @@ export const makeMessagesSocket = (config: SocketConfig) => {
 
 	const waitForMsgMediaUpdate = bindWaitForEvent(ev, 'messages.media-update')
 
+	const end: typeof sock.end = error => {
+		cleanupResources()
+		baseEnd(error)
+	}
+
 	return {
 		...sock,
+		end,
 		getPrivacyTokens,
 		assertSessions,
 		relayMessage,

--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -380,7 +380,7 @@ export const makeSocket = (config: SocketConfig) => {
 		const keyEnc = await noise.processHandshake(handshake, creds.noiseKey)
 
 		let node: proto.IClientPayload
-                if (!creds.me || !creds.registered) {
+		if (!creds.me || !creds.registered) {
 			node = generateRegistrationNode(creds, config)
 			logger.info({ node }, 'not logged in, attempting registration...')
 		} else {

--- a/src/Utils/message-retry-manager.ts
+++ b/src/Utils/message-retry-manager.ts
@@ -199,6 +199,21 @@ export class MessageRetryManager {
 		}
 	}
 
+	/**
+	 * Dispose the manager and clear timers/caches to avoid leaks
+	 */
+	shutdown(): void {
+		for (const timeout of Object.values(this.pendingPhoneRequests)) {
+			clearTimeout(timeout)
+		}
+
+		this.pendingPhoneRequests = {}
+		this.recentMessagesMap.clear()
+		this.sessionRecreateHistory.clear()
+		this.retryCounters.clear()
+		this.logger.debug('Message retry manager shutdown complete')
+	}
+
 	private keyToString(key: RecentMessageKey): string {
 		return `${key.to}:${key.id}`
 	}


### PR DESCRIPTION
## Summary
- close locally owned NodeCache instances when message sockets shut down to avoid lingering timers
- dispose the message retry manager on shutdown to cancel pending phone request timers and clear caches

## Testing
- yarn lint *(fails: existing prettier formatting errors in src/__tests__/Socket/messages-recv.retry.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68f46f5fd6d0832d88f5884e67818256