### PR TITLE
Reduce verbose node logging in socket handlers

### DIFF
--- a/src/Socket/communities.ts
+++ b/src/Socket/communities.ts
@@ -19,6 +19,15 @@ import {
 } from '../WABinary'
 import { makeBusinessSocket } from './business'
 
+const summarizeBinaryNode = (node?: BinaryNode | null) =>
+        node
+                ? {
+                        tag: node.tag,
+                        attrs: node.attrs,
+                        childTags: Array.isArray(node.content) ? node.content.map(child => child.tag) : undefined
+                }
+                : undefined
+
 export const makeCommunitiesSocket = (config: SocketConfig) => {
 	const sock = makeBusinessSocket(config)
 	const { authState, ev, query, upsertMessage } = sock
@@ -77,15 +86,15 @@ export const makeCommunitiesSocket = (config: SocketConfig) => {
 		return data
 	}
 
-	async function parseGroupResult(node: BinaryNode) {
-		logger.info({ node }, 'parseGroupResult')
-		const groupNode = getBinaryNodeChild(node, 'group')
-		if (groupNode) {
-			try {
-				logger.info({ groupNode }, 'groupNode')
-				const metadata = await sock.groupMetadata(`${groupNode.attrs.id}@g.us`)
-				return metadata ? metadata : Optional.empty()
-			} catch (error) {
+        async function parseGroupResult(node: BinaryNode) {
+                logger.info({ node: summarizeBinaryNode(node) }, 'parseGroupResult')
+                const groupNode = getBinaryNodeChild(node, 'group')
+                if (groupNode) {
+                        try {
+                                logger.info({ group: summarizeBinaryNode(groupNode) }, 'groupNode')
+                                const metadata = await sock.groupMetadata(`${groupNode.attrs.id}@g.us`)
+                                return metadata ? metadata : Optional.empty()
+                        } catch (error) {
 				console.error('Error parsing group metadata:', error)
 				return Optional.empty()
 			}


### PR DESCRIPTION
## Summary
- add helper to summarize BinaryNode instances before logging newsletter events
- downgrade unknown encrypt notification logging to debug with summarized context
- log summarized group results in community handler to avoid serializing full nodes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb286e6790832da64f61a15b9cfcc9