### PR TITLE
Handle unavailable service failures by resetting routing info

### DIFF
--- a/src/Socket/socket.ts
+++ b/src/Socket/socket.ts
@@ -907,18 +907,29 @@ export const makeSocket = (config: SocketConfig) => {
 		}
 	})
 
-	ws.on('CB:stream:error', (node: BinaryNode) => {
-		logger.error({ node }, 'stream errored out')
+        const clearRoutingInfoIfUnavailable = (statusCode?: number) => {
+                if (statusCode === DisconnectReason.unavailableService && authState.creds.routingInfo) {
+                        logger.warn('Clearing cached routing info due to unavailable service response')
+                        authState.creds.routingInfo = undefined
+                        ev.emit('creds.update', authState.creds)
+                }
+        }
 
-		const { reason, statusCode } = getErrorCodeFromStreamError(node)
+        ws.on('CB:stream:error', (node: BinaryNode) => {
+                logger.error({ node }, 'stream errored out')
 
-		end(new Boom(`Stream Errored (${reason})`, { statusCode, data: node }))
-	})
-	// stream fail, possible logout
-	ws.on('CB:failure', (node: BinaryNode) => {
-		const reason = +(node.attrs.reason || 500)
-		end(new Boom('Connection Failure', { statusCode: reason, data: node.attrs }))
-	})
+                const { reason, statusCode } = getErrorCodeFromStreamError(node)
+
+                clearRoutingInfoIfUnavailable(statusCode)
+
+                end(new Boom(`Stream Errored (${reason})`, { statusCode, data: node }))
+        })
+        // stream fail, possible logout
+        ws.on('CB:failure', (node: BinaryNode) => {
+                const reason = +(node.attrs.reason || 500)
+                clearRoutingInfoIfUnavailable(reason)
+                end(new Boom('Connection Failure', { statusCode: reason, data: node.attrs }))
+        })
 
 	ws.on('CB:ib,,downgrade_webclient', () => {
 		end(new Boom('Multi-device beta not joined', { statusCode: DisconnectReason.multideviceMismatch }))


### PR DESCRIPTION
## Summary
- clear cached routing info when WhatsApp reports the assigned edge is unavailable so that the next connection retries without the stale routing hint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb3f4e0ac8832dbe21ad072f694509